### PR TITLE
Move images to autopilotpattern repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-triton-nginx
+Nginx autopilot pattern
 ==========
 
 *An Nginx container for container-native deployment and automatic backend discovery.*

--- a/example/common-compose.yml
+++ b/example/common-compose.yml
@@ -2,7 +2,7 @@
 # deployment on Joyent's Triton platform.
 
 nginx:
-    image: 0x74696d/triton-nginx
+    image: autopilotpattern/nginx
     mem_limit: 512m
     ports:
     - 80
@@ -15,7 +15,7 @@ nginx:
       nginx -g "daemon off;"
 
 app:
-    image: 0x74696d/containerbuddy-demo-app
+    image: autopilotpattern/containerbuddy-demo-app
     mem_limit: 512m
     expose:
     - 8000 # not strictly necessary because we don't link

--- a/example/makefile
+++ b/example/makefile
@@ -23,5 +23,5 @@ run:
 
 # build and send up to the Docker Hub
 ship:
-	cd .. && docker build -t="0x74696d/triton-nginx" .
-	docker push 0x74696d/triton-nginx
+	cd .. && docker build -t="autopilotpattern/nginx" .
+	docker push autopilotpattern/nginx


### PR DESCRIPTION
@misterbisson this updates the repo to have container images moved under the autopilotpattern org.

The new images have been pushed to:
https://hub.docker.com/r/autopilotpattern/nginx/
https://hub.docker.com/r/autopilotpattern/containerbuddy-demo-app/