### PR TITLE
Fix Nginx virtualhost config and sensor calcs

### DIFF
--- a/bin/sensor.sh
+++ b/bin/sensor.sh
@@ -9,9 +9,8 @@ help() {
 
 # Cummulative number of dropped connections
 unhandled() {
-    local scraped=$(curl -s --fail localhost/health)
-    local accepts=$(echo ${scraped} | awk 'FNR == 3 {print $1}')
-    local handled=$(echo ${scraped} | awk 'FNR == 3 {print $2}')
+    local accepts=$(curl -s --fail localhost/health | awk 'FNR == 3 {print $1}')
+    local handled=$(curl -s --fail localhost/health | awk 'FNR == 3 {print $2}')
     echo $(expr ${accepts} - ${handled})
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ nginx:
         - BACKEND=example
     ports:
         - 80
+        - 9090 # so we can see telemetry
     labels:
         - triton.cns.services=nginx
 

--- a/etc/containerpilot.json
+++ b/etc/containerpilot.json
@@ -6,7 +6,7 @@
       "name": "nginx",
       "port": 80,
       "publicIp": true,
-      "health": "/usr/bin/curl --fail -s http://localhost/health.txt",
+      "health": "/usr/bin/curl --fail -s http://localhost/health",
       "poll": 10,
       "ttl": 25
     }

--- a/etc/nginx/nginx.conf.ctmpl
+++ b/etc/nginx/nginx.conf.ctmpl
@@ -29,36 +29,33 @@ http {
 
     #gzip  on;
 
-    # for each service, create a backend
-    {{range services}}
-    upstream {{.Name}} {
-             # write the health service address:port pairs for this backend
-             {{range service .Name}}
-             server {{.Address}}:{{.Port}};
-             {{end}}
-    }
-    {{end}}
+    {{ $backend := env "BACKEND" }}
+    {{ if service $backend }}
+    upstream {{ $backend }} {
+        # write the address:port pairs for each healthy backend instance
+        {{range service $backend }}
+        server {{.Address}}:{{.Port}};
+        {{end}}
+        least_conn;
+    }{{ end }}
 
     server {
         listen       80;
         server_name  _;
 
-        # if you have http_stub_status_module compiled-in, then
-        # this would be a good place to use /nginx_status
-        location /health.txt {
-            add_header content-type "text/html";
-            alias /usr/share/nginx/html/index.html;
+        location /health {
+            stub_status;
+            allow 127.0.0.1;
+            deny all;
+        }
+        {{ if service $backend }}
+        location = /{{ $backend }} {
+            return 301 /{{ $backend }}/;
         }
 
-        {{range services}}
-        location = /{{.Name}} {
-            return 301 /{{.Name}}/;
-        }
-
-        location /{{.Name}} {
-            proxy_pass http://{{.Name}}/;
+        location /{{ $backend }} {
+            proxy_pass http://{{ $backend }};
             proxy_redirect off;
-        }
-        {{end}}
+        }{{ end }}
     }
 }

--- a/local-compose.yml
+++ b/local-compose.yml
@@ -10,6 +10,7 @@ nginx:
         - consul:consul
     ports:
         - 80:80
+        - 9090:9090 # telemetry endpoint
 
 example:
     extends:


### PR DESCRIPTION
@misterbisson this PR includes:
- make our Nginx health check location block compatible with the sensors
- exposes telemetry to the end user for demonstration
- fixes a broken sensor
- incorporates the `BACKEND` env var into our Nginx config template