### PR TITLE
Deeper URL path to health info

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,13 +21,19 @@ RUN apt-get update \
         unzip \
     && rm -rf /var/lib/apt/lists/*
 
-# Add Consul from https://releases.hashicorp.com/consul
-RUN export CHECKSUM=abdf0e1856292468e2c9971420d73b805e93888e006c76324ae39416edcf0627 \
-    && curl -vo /tmp/consul.zip "https://releases.hashicorp.com/consul/0.6.4/consul_0.6.4_linux_amd64.zip" \
-    && echo "${CHECKSUM}  /tmp/consul.zip" | sha256sum -c \
+# Install Consul
+# Releases at https://releases.hashicorp.com/consul
+RUN export CONSUL_VERSION=0.6.4 \
+    && export CONSUL_CHECKSUM=abdf0e1856292468e2c9971420d73b805e93888e006c76324ae39416edcf0627 \
+    && curl --retry 7 --fail -vo /tmp/consul.zip "https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip" \
+    && echo "${CONSUL_CHECKSUM}  /tmp/consul.zip" | sha256sum -c \
     && unzip /tmp/consul -d /usr/local/bin \
     && rm /tmp/consul.zip \
     && mkdir /config
+
+# Create empty directories for Consul config and data
+RUN mkdir -p /etc/consul \
+    && mkdir -p /var/lib/consul
 
 # Install Consul template
 # Releases at https://releases.hashicorp.com/consul-template/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,18 @@
 # A minimal Nginx container including ContainerPilot and a simple virtualhost config
 FROM nginx:latest
 
+# Build-time metadata as defined at http://label-schema.org
+# with added usage described in https://microbadger.com/#/labels
+ARG BUILD_DATE
+ARG VCS_REF
+LABEL org.label-schema.build-date=$BUILD_DATE \
+    org.label-schema.docker.dockerfile="/Dockerfile" \
+    org.label-schema.name="Autopilot Pattern Nginx" \
+    org.label-schema.url="https://github.com/autopilotpattern/nginx" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-type="Git" \
+    org.label-schema.vcs-url="https://github.com/autopilotpattern/nginx"
+
 # Add some stuff via apt-get
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -17,13 +29,12 @@ RUN export CHECKSUM=abdf0e1856292468e2c9971420d73b805e93888e006c76324ae39416edcf
     && rm /tmp/consul.zip \
     && mkdir /config
 
-# Add Consul template
+# Install Consul template
 # Releases at https://releases.hashicorp.com/consul-template/
-ENV CONSUL_TEMPLATE_VERSION 0.14.0
-ENV CONSUL_TEMPLATE_SHA1 7c70ea5f230a70c809333e75fdcff2f6f1e838f29cfb872e1420a63cdf7f3a78
-
-RUN curl --retry 7 -Lso /tmp/consul-template.zip "https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION}/consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip" \
-    && echo "${CONSUL_TEMPLATE_SHA1}  /tmp/consul-template.zip" | sha256sum -c \
+RUN export CONSUL_TEMPLATE_VERSION=0.14.0 \
+    && export CONSUL_TEMPLATE_CHECKSUM=7c70ea5f230a70c809333e75fdcff2f6f1e838f29cfb872e1420a63cdf7f3a78 \
+    && curl --retry 7 --fail -Lso /tmp/consul-template.zip "https://releases.hashicorp.com/consul-template/${CONSUL_TEMPLATE_VERSION}/consul-template_${CONSUL_TEMPLATE_VERSION}_linux_amd64.zip" \
+    && echo "${CONSUL_TEMPLATE_CHECKSUM}  /tmp/consul-template.zip" | sha256sum -c \
     && unzip /tmp/consul-template.zip -d /usr/local/bin \
     && rm /tmp/consul-template.zip
 

--- a/README.md
+++ b/README.md
@@ -41,3 +41,12 @@ You can open the demo app that Nginx is proxying by opening a browser to the Ngi
 ```bash
 open "http://$(triton ip nginx_nginx_1)/example"
 ```
+
+### Building
+
+This image implements [microbadger.com](https://microbadger.com/#/labels) label schema, but those labels require additional build args:
+
+```
+docker build --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+               --build-arg VCS_REF=`git rev-parse --short HEAD` .
+```

--- a/bin/sensor.sh
+++ b/bin/sensor.sh
@@ -9,14 +9,14 @@ help() {
 
 # Cummulative number of dropped connections
 unhandled() {
-    local accepts=$(curl -s --fail localhost/health | awk 'FNR == 3 {print $1}')
-    local handled=$(curl -s --fail localhost/health | awk 'FNR == 3 {print $2}')
+    local accepts=$(curl -s --fail localhost/nginx-health | awk 'FNR == 3 {print $1}')
+    local handled=$(curl -s --fail localhost/nginx-health | awk 'FNR == 3 {print $2}')
     echo $(expr ${accepts} - ${handled})
 }
 
 # ratio of connections-in-use to available workers
 connections_load() {
-    local scraped=$(curl -s --fail localhost/health)
+    local scraped=$(curl -s --fail localhost/nginx-health)
     local active=$(echo ${scraped} | awk '/Active connections/{print $3}')
     local waiting=$(echo ${scraped} | awk '/Reading/{print $6}')
     local workers=$(echo $(cat /etc/nginx/nginx.conf | perl -n -e'/worker_connections *(\d+)/ && print $1')
@@ -31,40 +31,40 @@ connections_load() {
 
 # The current number of active client connections including Waiting connections.
 connections_active() {
-    curl -s localhost/health | awk '/Active connections/{print $3}'
+    curl -s localhost/nginx-health | awk '/Active connections/{print $3}'
 }
 
 # The current number of connections where nginx is reading the request header.
 connections_reading() {
-    curl -s localhost/health | awk '/Reading/{print $2}'
+    curl -s localhost/nginx-health | awk '/Reading/{print $2}'
 }
 
 # The current number of connections where nginx is writing the response back
 # to the client.
 connections_writing() {
-    curl -s localhost/health | awk '/Reading/{print $4}'
+    curl -s localhost/nginx-health | awk '/Reading/{print $4}'
 }
 
 # The current number of idle client connections waiting for a request.
 connections_waiting() {
-    curl -s localhost/health | awk '/Reading/{print $6}'
+    curl -s localhost/nginx-health | awk '/Reading/{print $6}'
 }
 
 # The total number of accepted client connections.
 accepts() {
-    curl -s localhost/health | awk 'FNR == 3 {print $1}'
+    curl -s localhost/nginx-health | awk 'FNR == 3 {print $1}'
 }
 
 # The total number of handled connections. Generally, the parameter value is the
 # same as accepts unless some resource limits have been reached (for example, the
 # worker_connections limit).
 handled() {
-    curl -s localhost/health | awk 'FNR == 3 {print $2}'
+    curl -s localhost/nginx-health | awk 'FNR == 3 {print $2}'
 }
 
 # The total number of client requests.
 requests() {
-    curl -s localhost/health | awk 'FNR == 3 {print $3}'
+    curl -s localhost/nginx-health | awk 'FNR == 3 {print $3}'
 }
 
 # -------------------------------------------------------

--- a/etc/containerpilot.json
+++ b/etc/containerpilot.json
@@ -33,14 +33,14 @@
     "port": 9090,
     "sensors": [
       {
-        "name": "tb_nginx_connections_unhandled_total",
+        "name": "nginx_connections_unhandled_total",
         "help": "Number of accepted connnections that were not handled",
         "type": "gauge",
         "poll": 5,
         "check": ["/usr/local/bin/sensor.sh", "unhandled"]
       },
       {
-        "name": "tb_nginx_connections_load",
+        "name": "nginx_connections_load",
         "help": "Ratio of active connections (less waiting) to the maximum worker connections",
         "type": "gauge",
         "poll": 5,

--- a/etc/containerpilot.json
+++ b/etc/containerpilot.json
@@ -21,8 +21,8 @@
   "coprocesses": [{{ if .CONSUL_AGENT }}
     {
       "command": ["/usr/local/bin/consul", "agent",
-                  "-data-dir=/data",
-                  "-config-dir=/config",
+                  "-data-dir=/var/lib/consul",
+                  "-config-dir=/etc/consul",
                   "-rejoin",
                   "-retry-join", "{{ .CONSUL }}",
                   "-retry-max", "10",

--- a/etc/containerpilot.json
+++ b/etc/containerpilot.json
@@ -6,7 +6,7 @@
     {
       "name": "nginx",
       "port": 80,
-      "health": "/usr/bin/curl --fail -s http://localhost/health",
+      "health": "/usr/bin/curl --fail -s http://localhost/nginx-health",
       "poll": 10,
       "ttl": 25
     }


### PR DESCRIPTION
The deeper path reduces the risk of URL conflicts with other uses.

And...

- added Docker labels
- improved consul-template install

If merged, this should be [tagged as `1-r4`](https://hub.docker.com/r/autopilotpattern/nginx/tags/)