### PR TITLE
Wrong stub_status location

### DIFF
--- a/etc/nginx/nginx.conf.ctmpl
+++ b/etc/nginx/nginx.conf.ctmpl
@@ -43,7 +43,7 @@ http {
         listen       80;
         server_name  _;
 
-        location /health {
+        location /nginx-health {
             stub_status;
             allow 127.0.0.1;
             deny all;


### PR DESCRIPTION
I believe it's a typo. In all places I see links to _/nginx-health_ , when in fact location here is just _/health_