### PR TITLE
Make default health check a little bit quietly

### DIFF
--- a/etc/containerpilot.json
+++ b/etc/containerpilot.json
@@ -6,7 +6,7 @@
     {
       "name": "nginx",
       "port": 80,
-      "health": "/usr/bin/curl --fail -s http://localhost/nginx-health",
+      "health": "/usr/bin/curl --fail --silent --show-error --output /dev/null http://localhost/nginx-health",
       "poll": 10,
       "ttl": 25
     }


### PR DESCRIPTION
Your curl options shows output of every single request in the stdout. I don't see why it used by default.
I propose make it quiet and log errors only