### PR TITLE
Add nginx-public service

### DIFF
--- a/etc/containerpilot.json
+++ b/etc/containerpilot.json
@@ -8,7 +8,16 @@
       "port": 80,
       "health": "/usr/bin/curl --fail --silent --show-error --output /dev/null http://localhost/nginx-health",
       "poll": 10,
-      "ttl": 25
+      "ttl": 25,
+      "interfaces": ["eth0"]
+    },
+    {
+      "name": "nginx-public",
+      "port": 80,
+      "health": "/usr/bin/curl --fail --silent --show-error --output /dev/null http://localhost/nginx-health",
+      "poll": 10,
+      "ttl": 25,
+      "interfaces": ["eth1", "eth0"]
     }
   ],
   "backends": [


### PR DESCRIPTION
For https://github.com/autopilotpattern/nginx/issues/26

This adds the nginx-public service advertisement that may be used to obtain the public IP assigned to the Nginx container.