### PR TITLE
Default Consul host to consul

### DIFF
--- a/bin/acme
+++ b/bin/acme
@@ -4,13 +4,9 @@ pushd `dirname $0` > /dev/null
 SCRIPTPATH=`pwd -P`
 popd > /dev/null
 
-CONSUL_HOST_DEFAULT="consul"
+CONSUL_HOST_DEFAULT=${CONSUL:-consul}
 if [ "${CONSUL_AGENT}" != "" ]; then
     CONSUL_HOST_DEFAULT="localhost"
-else
-    if [ "${CONSUL}" != "" ]; then
-        CONSUL_HOST_DEFAULT=${CONSUL}
-    fi
 fi
 CONSUL_HOST=${CONSUL_HOST:-$CONSUL_HOST_DEFAULT}
 CONSUL_ROOT="http://${CONSUL_HOST}:8500/v1"

--- a/bin/acme
+++ b/bin/acme
@@ -4,9 +4,13 @@ pushd `dirname $0` > /dev/null
 SCRIPTPATH=`pwd -P`
 popd > /dev/null
 
-CONSUL_HOST_DEFAULT="localhost"
-if [ "${CONSUL_AGENT}" = "" -a "${CONSUL}" != "" ]; then
-    CONSUL_HOST_DEFAULT=${CONSUL}
+CONSUL_HOST_DEFAULT="consul"
+if [ "${CONSUL_AGENT}" != "" ]; then
+    CONSUL_HOST_DEFAULT="localhost"
+else
+    if [ "${CONSUL}" != "" ]; then
+        CONSUL_HOST_DEFAULT=${CONSUL}
+    fi
 fi
 CONSUL_HOST=${CONSUL_HOST:-$CONSUL_HOST_DEFAULT}
 CONSUL_ROOT="http://${CONSUL_HOST}:8500/v1"

--- a/etc/acme/dehydrated/hook.sh
+++ b/etc/acme/dehydrated/hook.sh
@@ -1,13 +1,9 @@
 #!/usr/bin/env bash
 set -o pipefail
 
-CONSUL_HOST_DEFAULT="consul"
+CONSUL_HOST_DEFAULT=${CONSUL:-consul}
 if [ "${CONSUL_AGENT}" != "" ]; then
     CONSUL_HOST_DEFAULT="localhost"
-else
-    if [ "${CONSUL}" != "" ]; then
-        CONSUL_HOST_DEFAULT=${CONSUL}
-    fi
 fi
 CONSUL_HOST=${CONSUL_HOST:-$CONSUL_HOST_DEFAULT}
 CONSUL_ROOT="http://${CONSUL_HOST}:8500/v1"

--- a/etc/acme/dehydrated/hook.sh
+++ b/etc/acme/dehydrated/hook.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 set -o pipefail
 
-CONSUL_HOST_DEFAULT="localhost"
-if [ "${CONSUL_AGENT}" = "" -a "${CONSUL}" != "" ]; then
-    CONSUL_HOST_DEFAULT=${CONSUL}
+CONSUL_HOST_DEFAULT="consul"
+if [ "${CONSUL_AGENT}" != "" ]; then
+    CONSUL_HOST_DEFAULT="localhost"
+else
+    if [ "${CONSUL}" != "" ]; then
+        CONSUL_HOST_DEFAULT=${CONSUL}
+    fi
 fi
 CONSUL_HOST=${CONSUL_HOST:-$CONSUL_HOST_DEFAULT}
 CONSUL_ROOT="http://${CONSUL_HOST}:8500/v1"

--- a/etc/containerpilot.json
+++ b/etc/containerpilot.json
@@ -1,5 +1,5 @@
 {
-  "consul": "{{ if .CONSUL_AGENT }}localhost{{ else }}{{ .CONSUL }}{{ end }}:8500",
+  "consul": "{{ if .CONSUL_AGENT }}localhost{{ else }}{{ if .CONSUL }}{{ .CONSUL }}{{ else }}consul{{ end }}{{ end }}:8500",
   "preStart": "/usr/local/bin/reload.sh preStart",
   "logging": {"level": "DEBUG"},
   "services": [
@@ -41,7 +41,7 @@
                   "-data-dir=/var/lib/consul",
                   "-config-dir=/etc/consul",
                   "-rejoin",
-                  "-retry-join", "{{ .CONSUL }}",
+                  "-retry-join", "{{ if .CONSUL }}{{ .CONSUL }}{{ else }}consul{{ end }}",
                   "-retry-max", "10",
                   "-retry-interval", "10s"],
       "restarts": "unlimited"
@@ -51,7 +51,7 @@
     {
       "command": ["/usr/local/bin/consul-template",
                   "-config", "/etc/acme/watch.hcl",
-                  "-consul", "{{ if .CONSUL_AGENT }}localhost{{ else }}{{ .CONSUL }}{{ end }}:8500"],
+                  "-consul", "{{ if .CONSUL_AGENT }}localhost{{ else }}{{ if .CONSUL }}{{ .CONSUL }}{{ else }}consul{{ end }}{{ end }}:8500"],
       "restarts": "unlimited"
     }{{ end }}],
   "telemetry": {

--- a/example-backend/containerpilot.json
+++ b/example-backend/containerpilot.json
@@ -1,5 +1,5 @@
 {
-  "consul": "{{ if .CONSUL_AGENT }}localhost{{ else }}{{ .CONSUL }}{{ end }}:8500",
+  "consul": "{{ if .CONSUL_AGENT }}localhost{{ else }}{{ if .CONSUL }}{{ .CONSUL }}{{ else }}consul{{ end }}{{ end }}:8500",
   "services": [
     {
       "name": "example",


### PR DESCRIPTION
In the event there is no CONSUL environment variable, use `consul`, which will target the linked Consul container.