### PR TITLE
Add additional headers

### DIFF
--- a/etc/containerpilot.json
+++ b/etc/containerpilot.json
@@ -20,9 +20,17 @@
       "interfaces": ["eth1", "eth0"]
     }{{ if .ACME_DOMAIN }},
     {
-      "name": "nginx-public-ssl",
+      "name": "nginx-ssl",
       "port": 443,
       "health": "/usr/local/bin/acme init && /usr/bin/curl --insecure --fail --silent --show-error --output /dev/null --header \"HOST: {{ .ACME_DOMAIN }}\" https://localhost/nginx-health",
+      "poll": 10,
+      "ttl": 25,
+      "interfaces": ["eth0"]
+    },
+    {
+      "name": "nginx-public-ssl",
+      "port": 443,
+      "health": "/usr/bin/curl --insecure --fail --silent --show-error --output /dev/null --header \"HOST: {{ .ACME_DOMAIN }}\" https://localhost/nginx-health",
       "poll": 10,
       "ttl": 25,
       "interfaces": ["eth1", "eth0"]

--- a/etc/nginx/nginx.conf.ctmpl
+++ b/etc/nginx/nginx.conf.ctmpl
@@ -46,56 +46,33 @@ http {
         least_conn;
     }{{ end }}
 
-    server {
-        listen      80;
+    # If we're listening on https, define an http listener that redirects everything to https
+    {{ if eq $ssl_ready "true" }}
+    server { 
         server_name _;
+        listen      80;
 
-        {{ if eq $ssl_ready "true" }}
         location / {
             return 301 https://$host$request_uri;
         }
-        {{ end }}
-
-        {{ if ne $ssl_ready "true" }}
-        location /.well-known/acme-challenge {
-            alias /var/www/acme/challenge;
-        }
-
-        {{ if service $backend }}
-        location = /{{ $backend }} {
-            return 301 /{{ $backend }}/;
-        }
-        location /{{ $backend }} {
-            proxy_pass http://{{ $backend }};
-            proxy_redirect off;
-        }
-        {{ end }}
-        {{ end }}
-
+        
+        # Respond to health requests defined in containerpilot.json
         location /nginx-health {
             stub_status;
             allow 127.0.0.1;
             deny all;
+            # Don't log these requests unless they fail
             access_log /var/log/nginx/access.log  main if=$isError;
         }
     }
+    {{ end }}
 
     {{ if eq $ssl_ready "true" }}
     server {
-        listen       443 ssl;
         server_name  _;
-
-        location /nginx-health {
-            stub_status;
-            allow 127.0.0.1;
-            deny all;
-            access_log /var/log/nginx/access.log  main if=$isError;
-        }
-
-        location /.well-known/acme-challenge {
-            alias /var/www/acme/challenge;
-        }
-
+        # Listen on port 80 unless we have certificates installed, then listen on 443
+        listen {{ if ne $ssl_ready "true" }}80{{ else }}443 ssl{{ end }};
+        {{ if eq $ssl_ready "true" }}
         ssl_certificate /var/www/ssl/fullchain.pem;
         ssl_certificate_key /var/www/ssl/privkey.pem;
         ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
@@ -106,6 +83,18 @@ http {
         ssl_stapling on;
         ssl_stapling_verify on;
         add_header Strict-Transport-Security max-age=15768000;
+        {{ end }}
+            
+        location /nginx-health {
+            stub_status;
+            allow 127.0.0.1;
+            deny all;
+            access_log /var/log/nginx/access.log  main if=$isError;
+        }
+
+        location /.well-known/acme-challenge {
+            alias /var/www/acme/challenge;
+        }
 
         {{ if service $backend }}
         location = /{{ $backend }} {
@@ -115,6 +104,9 @@ http {
         location /{{ $backend }} {
             proxy_pass http://{{ $backend }};
             proxy_redirect off;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }{{ end }}
     }
     {{ end }}


### PR DESCRIPTION
Added additional "best practice" headers on the proxied request:

* `X-Forwarded-Proto`
* `X-Real-IP` 
* `X-Forwarded-For`

Also removed some redundancy within the config to further simplify and streamline it.