### PR TITLE
Add support for multiple BACKEND by having them space-separated

### DIFF
--- a/etc/nginx/nginx.conf.ctmpl
+++ b/etc/nginx/nginx.conf.ctmpl
@@ -37,14 +37,19 @@ http {
     {{ $backend := env "BACKEND" }}
     {{ $acme_domain := env "ACME_DOMAIN" }}
     {{ $ssl_ready := env "SSL_READY" }}
-    {{ if service $backend }}
-    upstream {{ $backend }} {
+
+		# loop for each backend
+		{{ range $b := $backend | split " " }}
+    {{ if service $b }}
+    upstream {{ $b }} {
         # write the address:port pairs for each healthy backend instance
-        {{range service $backend }}
+        {{range service $b }}
         server {{.Address}}:{{.Port}};
         {{end}}
         least_conn;
     }{{ end }}
+		{{ end }}
+		# end loop for each backend
 
     server {
         listen      80;
@@ -61,14 +66,16 @@ http {
             alias /var/www/acme/challenge;
         }
 
-        {{ if service $backend }}
-        location = /{{ $backend }} {
-            return 301 /{{ $backend }}/;
+				{{ range $b := $backend | split " " }}
+        {{ if service $b }}
+        location = /{{ $b }} {
+            return 301 /{{ $b }}/;
         }
-        location /{{ $backend }} {
-            proxy_pass http://{{ $backend }};
+        location /{{ $b }} {
+            proxy_pass http://{{ $b }};
             proxy_redirect off;
         }
+				{{ end }}
         {{ end }}
         {{ end }}
 
@@ -107,15 +114,17 @@ http {
         ssl_stapling_verify on;
         add_header Strict-Transport-Security max-age=15768000;
 
-        {{ if service $backend }}
-        location = /{{ $backend }} {
-            return 301 /{{ $backend }}/;
+				{{ range $b := $backend | split " " }}
+        {{ if service $b }}
+        location = /{{ $b }} {
+            return 301 /{{ $b }}/;
         }
 
-        location /{{ $backend }} {
-            proxy_pass http://{{ $backend }};
+        location /{{ $b }} {
+            proxy_pass http://{{ $b }};
             proxy_redirect off;
         }{{ end }}
+				{{ end }}
     }
     {{ end }}
 }


### PR DESCRIPTION
Small thing, but useful.

Sometimes you have a proxy in front of multiple services. The example nginx _already_ has the backend proxied as `/<backend_service>`, so it is useful to have multiple. Just set `BACKEND` to be space-separated multiple service names, and it creates multiple.

E.g. `BACKEND="auth data wordpress"` will create three proxied URLs:

* `/auth`
* `/data`
* `/wordpress`

