### PR TITLE
Clean up key management in testing

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -73,15 +73,12 @@ pull-examples:
 	docker pull $(backend):$(tag)
 	docker pull $(testImage):$(tag)
 
-$(DOCKER_CERT_PATH)/key.pub:
-	ssh-keygen -y -f $(DOCKER_CERT_PATH)/key.pem > $(DOCKER_CERT_PATH)/key.pub
-
-# For Jenkins test runner only: make sure we have public keys available
-SDC_KEYS_VOL ?= -v $(DOCKER_CERT_PATH):$(DOCKER_CERT_PATH)
-keys: $(DOCKER_CERT_PATH)/key.pub
 
 run-local:
 	cd ../examples/compose && TAG=$(tag) docker-compose up -d
+
+# Make keys available when running tests from a container
+SDC_KEYS_VOL ?= -v $(DOCKER_CERT_PATH):$(DOCKER_CERT_PATH) -v $(HOME)/.ssh:/root.ssh
 
 ## Run the integration test runner. Runs locally but targets Triton.
 test:


### PR DESCRIPTION
This PR cleans up the key management in the testing makefile so that we're not assuming specific key names. This is made possible by the changes in https://github.com/joyent/product-automation/pull/12. The Jenkins task ends up looking like this:

```bash
export SDC_KEYS_VOL="-v /var/jenkins_home:/var/jenkins_home"
export TRITON_ACCOUNT=7e7c44c4-a114-4a7e-9e2f-402a110359f5
export TRITON_DC=us-sw-1
eval $(triton env triton-us-sw-1)
cd test && make pull-examples test
```

cc @misterbisson 