### PR TITLE
Consul key/value collision

### DIFF
--- a/bin/acme
+++ b/bin/acme
@@ -128,7 +128,7 @@ case "$1" in
         acquireLeader
         ;;
     watch)
-        /usr/local/bin/consul-template -config /etc/acme/watch.hcl -consul $CONSUL_HOST:8500
+        /usr/local/bin/consul-template -config /etc/acme/watch.hcl -consul-addr $CONSUL_HOST:8500
         ;;
     init)
         if [ -f ${CERT_DIR}/fullchain.pem -a -f ${CERT_DIR}/privkey.pem ]; then

--- a/bin/acme
+++ b/bin/acme
@@ -4,13 +4,14 @@ pushd `dirname $0` > /dev/null
 SCRIPTPATH=`pwd -P`
 popd > /dev/null
 
+SERVICE_NAME=${SERVICE_NAME:-nginx}
 CONSUL_HOST_DEFAULT=${CONSUL:-consul}
 if [ "${CONSUL_AGENT}" != "" ]; then
     CONSUL_HOST_DEFAULT="localhost"
 fi
 CONSUL_HOST=${CONSUL_HOST:-$CONSUL_HOST_DEFAULT}
 CONSUL_ROOT="http://${CONSUL_HOST}:8500/v1"
-CONSUL_KEY_ROOT="${CONSUL_ROOT}/kv/nginx"
+CONSUL_KEY_ROOT="${CONSUL_ROOT}/kv/${SERVICE_NAME}"
 
 SESSION_DIR_DEFAULT="/var/consul"
 SESSION_DIR=${SESSION_DIR:-$SESSION_DIR_DEFAULT}
@@ -22,7 +23,7 @@ CERT_DIR="/var/www/ssl"
 ACME_ENV=${ACME_ENV:-staging}
 
 function getConsulSession () {
-    if [ -f $SESSION_FILE ]; then 
+    if [ -f $SESSION_FILE ]; then
         SID=$(cat ${SESSION_DIR}/session)
         local STATUS=$(curl -s ${CONSUL_ROOT}/session/info/${SID})
         if [ "${STATUS}" != "[]" ]; then
@@ -39,7 +40,7 @@ function getConsulSession () {
 function renewConsulSession () {
     local SID="$(getConsulSession)"
     rc=$?
-    if [ $rc -ne 0 ]; then 
+    if [ $rc -ne 0 ]; then
         createConsulSession
         return $?
     else

--- a/etc/acme/dehydrated/hook.sh
+++ b/etc/acme/dehydrated/hook.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 set -o pipefail
 
+SERVICE_NAME=${SERVICE_NAME:-nginx}
 CONSUL_HOST_DEFAULT=${CONSUL:-consul}
 if [ "${CONSUL_AGENT}" != "" ]; then
     CONSUL_HOST_DEFAULT="localhost"
 fi
 CONSUL_HOST=${CONSUL_HOST:-$CONSUL_HOST_DEFAULT}
 CONSUL_ROOT="http://${CONSUL_HOST}:8500/v1"
-CONSUL_KEY_ROOT="${CONSUL_ROOT}/kv/nginx"
+CONSUL_KEY_ROOT="${CONSUL_ROOT}/kv/${SERVICE_NAME}"
 CHALLENGE_PATH="/.well-known/acme-challenge"
 
 function deploy_challenge {

--- a/etc/acme/templates/cert.ctmpl
+++ b/etc/acme/templates/cert.ctmpl
@@ -1,1 +1,2 @@
-{{if key "nginx/acme/cert"}}{{key "nginx/acme/cert"}}{{end}}
+{{ $service_name := env "SERVICE_NAME" }}
+{{if key (print $service_name "/acme/cert")}}{{key (print $service_name "/acme/key")}}{{end}}

--- a/etc/acme/templates/chain.ctmpl
+++ b/etc/acme/templates/chain.ctmpl
@@ -1,1 +1,2 @@
-{{if key "nginx/acme/chain"}}{{key "nginx/acme/chain"}}{{end}}
+{{ $service_name := env "SERVICE_NAME" }}
+{{if key (print $service_name "/acme/chain")}}{{key (print $service_name "/acme/chain")}}{{end}}

--- a/etc/acme/templates/challenge-token.ctmpl
+++ b/etc/acme/templates/challenge-token.ctmpl
@@ -1,3 +1,4 @@
-{{if key "nginx/acme/challenge/token-filename"}}{{key "nginx/acme/challenge/token-filename"}}{{end}}
-{{if key "nginx/acme/challenge/token-value"}}{{key "nginx/acme/challenge/token-value"}}{{end}}
-{{if key "nginx/acme/challenge/last-token-filename"}}{{key "nginx/acme/challenge/last-token-filename"}}{{end}}
+{{ $service_name := env "SERVICE_NAME" }}
+{{if key (print $service_name "/acme/token-filename")}}{{key (print $service_name "/acme/token-filename")}}{{end}}
+{{if key (print $service_name "/acme/token-value")}}{{key (print $service_name "/acme/token-value")}}{{end}}
+{{if key (print $service_name "/acme/last-token-filename")}}{{key (print $service_name "/acme/last-token-filename")}}{{end}}

--- a/etc/acme/templates/fullchain.ctmpl
+++ b/etc/acme/templates/fullchain.ctmpl
@@ -1,1 +1,2 @@
-{{if key "nginx/acme/fullchain"}}{{key "nginx/acme/fullchain"}}{{end}}
+{{ $service_name := env "SERVICE_NAME" }}
+{{if key (print $service_name "/acme/fullchain")}}{{key (print $service_name "/acme/fullchain")}}{{end}}

--- a/etc/acme/templates/privkey.ctmpl
+++ b/etc/acme/templates/privkey.ctmpl
@@ -1,1 +1,2 @@
-{{if key "nginx/acme/key"}}{{key "nginx/acme/key"}}{{end}}
+{{ $service_name := env "SERVICE_NAME" }}
+{{if key (print $service_name "/acme/key")}}{{key (print $service_name "/acme/key")}}{{end}}


### PR DESCRIPTION
Not sure if this is a common use-case but is something I ran into recently. I have several front end load balancers where I want to perform SSL termination. Since I don’t want to run several Consul clusters I ran into an issue where they all use the same keys. I’m also not sure if I have caught all the places where `nginx` is hard coded but this DOES work in production for me.