### PR TITLE
Temporarily resolve #55 

### DIFF
--- a/etc/acme/dehydrated/config.production
+++ b/etc/acme/dehydrated/config.production
@@ -1,2 +1,3 @@
 CA="https://acme-v01.api.letsencrypt.org/directory"
 WELLKNOWN="/var/www/acme/challenge"
+LICENSE="https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf"

--- a/etc/acme/dehydrated/config.staging
+++ b/etc/acme/dehydrated/config.staging
@@ -1,2 +1,3 @@
 CA="https://acme-staging.api.letsencrypt.org/directory"
 WELLKNOWN="/var/www/acme/challenge"
+LICENSE="https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf"


### PR DESCRIPTION
Addresses #55 with a minimum amount of hassle by adding the latest license URL into the dehydrated configs. I looked at newer versions of dehydrated and saw some changes that might need testing first so this seems like a quick and safe fix until we can evaluate newer versions.